### PR TITLE
修改：移除0.4  0.6  1.6GHz频率

### DIFF
--- a/patches/lean/993-cpu_fuck.patch
+++ b/patches/lean/993-cpu_fuck.patch
@@ -1,0 +1,51 @@
+From 292c89350611ee700d50aead934beb4f0fb29374 Mon Sep 17 00:00:00 2001
+From: GitHub <git@github.com>
+Date: Sun, 7 Nov 2021 21:24:52 +0800
+Subject: [PATCH] cpu_fuck
+
+---
+ arch/arm64/boot/dts/rockchip/rk3328.dtsi | 17 +----------------
+ 1 file changed, 1 insertion(+), 16 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3328.dtsi b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+index 72a5f4b5b..3243e9819 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3328.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3328.dtsi
+@@ -109,21 +109,11 @@
+ 		compatible = "operating-points-v2";
+ 		opp-shared;
+ 
+-		opp-408000000 {
+-			opp-hz = /bits/ 64 <408000000>;
+-			opp-microvolt = <950000>;
+-			clock-latency-ns = <40000>;
+-			opp-suspend;
+-		};
+-		opp-600000000 {
+-			opp-hz = /bits/ 64 <600000000>;
+-			opp-microvolt = <950000>;
+-			clock-latency-ns = <40000>;
+-		};
+ 		opp-816000000 {
+ 			opp-hz = /bits/ 64 <816000000>;
+ 			opp-microvolt = <1000000>;
+ 			clock-latency-ns = <40000>;
++			opp-suspend;
+ 		};
+ 		opp-1008000000 {
+ 			opp-hz = /bits/ 64 <1008000000>;
+@@ -150,11 +140,6 @@
+ 			opp-microvolt = <1400000>;
+ 			clock-latency-ns = <40000>;
+ 		};
+-		opp-1608000000 {
+-			opp-hz = /bits/ 64 <1608000000>;
+-			opp-microvolt = <1450000>;
+-			clock-latency-ns = <40000>;
+-		};
+ 	};
+ 
+ 	amba {
+-- 
+2.25.1
+


### PR DESCRIPTION
此补丁删除频率，当前默认频率最低0.8，最高1.5，防止低频死机